### PR TITLE
Fix duplicate 'run' argument and add Claude Code documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,54 @@ Lists installed libraries (globally or for a project).
    - "Upload firmware to my ESP32"
    - "Search for WiFi libraries"
 
+## Usage with Claude Code
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's official CLI tool for Claude. It supports MCP servers for extending Claude's capabilities.
+
+### Configuration
+
+Add the server to your Claude Code settings file (`~/.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "platformio": {
+      "command": "node",
+      "args": ["/path/to/platformio-mcp/build/index.js"]
+    }
+  }
+}
+```
+
+For project-specific configuration, create `.claude/settings.json` in your project root.
+
+### Available Tools
+
+Once configured, Claude Code can use these MCP tools directly:
+
+- `mcp__platformio__list_boards` - Discover available boards
+- `mcp__platformio__get_board_info` - Get board specifications
+- `mcp__platformio__list_devices` - Find connected devices
+- `mcp__platformio__init_project` - Create new projects
+- `mcp__platformio__build_project` - Compile firmware
+- `mcp__platformio__clean_project` - Clean build artifacts
+- `mcp__platformio__upload_firmware` - Flash to device
+- `mcp__platformio__start_monitor` - Get monitor command
+- `mcp__platformio__search_libraries` - Search library registry
+- `mcp__platformio__install_library` - Install libraries
+- `mcp__platformio__list_installed_libraries` - List installed libraries
+
+### Example Workflow
+
+```
+You: Build my ESP32 project and upload it
+
+Claude Code: I'll build and upload your project.
+[Uses mcp__platformio__build_project]
+[Uses mcp__platformio__upload_firmware]
+Build successful! Firmware uploaded to /dev/cu.usbserial-0001
+```
+
 ## Development
 
 ```bash
@@ -300,6 +348,56 @@ await installLibrary("ArduinoJson", {
   version: "^6.21.0"
 });
 ```
+
+### ESP32 Development with Claude Code
+
+When using Claude Code with ESP32 projects, you can leverage natural language for common tasks:
+
+**Project Setup:**
+```
+You: Create a new ESP32-S2 project for the Adafruit Feather board with Arduino framework
+
+Claude Code: I'll set that up for you.
+[Uses mcp__platformio__init_project with board="featheresp32-s2", framework="arduino"]
+```
+
+**Finding the Right Board:**
+```
+You: What ESP32 boards support the ESP-IDF framework?
+
+Claude Code: Let me search for compatible boards.
+[Uses mcp__platformio__list_boards with filter="espressif32"]
+```
+
+**Library Management:**
+```
+You: I need a library for controlling stepper motors with acceleration
+
+Claude Code: I'll search the registry for stepper libraries.
+[Uses mcp__platformio__search_libraries with query="stepper acceleration"]
+Found: FastAccelStepper, AccelStepper, ESP-FlexyStepper...
+```
+
+**Build and Deploy Workflow:**
+```
+You: Build my project, upload it, and tell me how to monitor the output
+
+Claude Code:
+[Uses mcp__platformio__build_project]
+Build successful - 70% flash used
+[Uses mcp__platformio__upload_firmware]
+Uploaded to /dev/cu.usbserial-0001
+[Uses mcp__platformio__start_monitor]
+Run: pio device monitor -b 115200
+```
+
+**Common ESP32 Board IDs:**
+- `esp32dev` - Generic ESP32 DevKit
+- `featheresp32-s2` - Adafruit Feather ESP32-S2
+- `esp32-s3-devkitc-1` - ESP32-S3 DevKitC
+- `esp32-c3-devkitm-1` - ESP32-C3 DevKitM
+- `lolin_d32` - Wemos LOLIN D32
+- `esp32thing` - SparkFun ESP32 Thing
 
 ## Troubleshooting
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -45,7 +45,7 @@ pio --version
 ### Step 1: Navigate to Server Directory
 
 ```bash
-cd /Users/tonyloehr/Desktop/Workspace/platformio-mcp
+cd /path/to/platformio-mcp
 ```
 
 ### Step 2: Install Dependencies
@@ -124,7 +124,7 @@ To use this server with Cline, add it to your MCP settings:
   "mcpServers": {
     "platformio": {
       "command": "node",
-      "args": ["/Users/tonyloehr/Desktop/Workspace/platformio-mcp/build/index.js"],
+      "args": ["/path/to/platformio-mcp/build/index.js"],
       "env": {}
     }
   }
@@ -138,12 +138,49 @@ To use this server with Cline, add it to your MCP settings:
     "platformio": {
       "command": "npm",
       "args": ["run", "dev"],
-      "cwd": "/Users/tonyloehr/Desktop/Workspace/platformio-mcp",
+      "cwd": "/path/to/platformio-mcp",
       "env": {}
     }
   }
 }
 ```
+
+## Configuration for Claude Code
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's official CLI for Claude with native MCP support.
+
+**Location:** `~/.claude/settings.json` (global) or `.claude/settings.json` (project-specific)
+
+**Configuration Example:**
+```json
+{
+  "mcpServers": {
+    "platformio": {
+      "command": "node",
+      "args": ["/path/to/platformio-mcp/build/index.js"]
+    }
+  }
+}
+```
+
+**Verify installation:**
+```bash
+# Start Claude Code - MCP tools load automatically
+claude
+
+# You can check available MCP tools with:
+/mcp
+```
+
+**Usage in Claude Code:**
+
+Once configured, interact naturally with your embedded projects:
+- "Build my PlatformIO project"
+- "What ESP32 boards are available?"
+- "Upload firmware to my connected device"
+- "Search for a JSON parsing library"
+
+Claude Code will automatically use the appropriate MCP tools (`mcp__platformio__build_project`, etc.).
 
 ## Troubleshooting
 
@@ -151,7 +188,7 @@ To use this server with Cline, add it to your MCP settings:
 
 **Solution:**
 ```bash
-cd /Users/tonyloehr/Desktop/Workspace/platformio-mcp
+cd /path/to/platformio-mcp
 rm -rf node_modules package-lock.json
 npm install
 ```
@@ -198,7 +235,7 @@ Run these commands to verify everything works:
 
 ```bash
 # 1. Check directory structure
-ls -la /Users/tonyloehr/Desktop/Workspace/platformio-mcp
+ls -la /path/to/platformio-mcp
 
 # 2. Verify dependencies
 npm list --depth=0
@@ -220,7 +257,7 @@ pio boards | head -5
 If something goes wrong, clean reinstall:
 
 ```bash
-cd /Users/tonyloehr/Desktop/Workspace/platformio-mcp
+cd /path/to/platformio-mcp
 rm -rf node_modules build package-lock.json
 npm install
 npm run build

--- a/src/tools/build.ts
+++ b/src/tools/build.ts
@@ -22,7 +22,7 @@ export async function buildProject(
   }
 
   try {
-    const args: string[] = ['run'];
+    const args: string[] = [];
 
     // Add environment if specified
     if (environment) {
@@ -109,13 +109,13 @@ export async function buildTarget(
   }
 
   try {
-    const args: string[] = ['run', '--target', target];
+    const args: string[] = ['--target', target];
 
     if (environment) {
       args.push('--environment', environment);
     }
 
-    const result = await platformioExecutor.execute('run', args.slice(1), {
+    const result = await platformioExecutor.execute('run', args, {
       cwd: validatedPath,
       timeout: 600000,
     });
@@ -150,13 +150,13 @@ export async function listTargets(projectDir: string, environment?: string): Pro
   const validatedPath = validateProjectPath(projectDir);
 
   try {
-    const args: string[] = ['run', '--list-targets'];
+    const args: string[] = ['--list-targets'];
 
     if (environment) {
       args.push('--environment', environment);
     }
 
-    const result = await platformioExecutor.execute('run', args.slice(1), {
+    const result = await platformioExecutor.execute('run', args, {
       cwd: validatedPath,
       timeout: 30000,
     });


### PR DESCRIPTION
## Summary

- **Bug Fix**: Fixed duplicate 'run' argument in build functions that caused `pio run run` error
- **Documentation**: Added Claude Code configuration and ESP32 workflow examples

## Bug Fix Details

The `buildProject` function was adding 'run' to the args array, but `platformioExecutor.execute()` already prepends the command to args. This resulted in `pio run run` being executed, causing:
```
Error: Got unexpected extra argument (run)
```

### Changes to `src/tools/build.ts`:
- `buildProject`: Changed `const args = ['run']` → `const args = []`
- `buildTarget`: Removed 'run' from args, removed `.slice(1)` workaround
- `listTargets`: Removed 'run' from args, removed `.slice(1)` workaround

## Documentation Additions

### README.md
- Added "Usage with Claude Code" section with configuration examples
- Added ESP32 development workflow examples showing natural language interactions
- Added common ESP32 board IDs reference

### llms-install.md
- Added "Configuration for Claude Code" section
- Replaced hardcoded paths with generic `/path/to/platformio-mcp`

## Test Plan

- [x] Verified `mcp__platformio__build_project` works correctly after fix
- [x] Tested with ESP32-S2 project (GTStepper) - build successful
- [ ] Maintainer review of documentation accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)