### PR TITLE
Add upload_filesystem tool for SPIFFS/LittleFS deployment

### DIFF
--- a/src/tools/upload.ts
+++ b/src/tools/upload.ts
@@ -136,3 +136,62 @@ export async function buildAndUpload(
   // Upload target automatically builds first if needed
   return uploadFirmware(projectDir, port, environment);
 }
+
+/**
+ * Uploads filesystem (SPIFFS/LittleFS) to a connected device
+ */
+export async function uploadFilesystem(
+  projectDir: string,
+  port?: string,
+  environment?: string
+): Promise<UploadResult> {
+  const validatedPath = validateProjectPath(projectDir);
+
+  if (environment && !validateEnvironmentName(environment)) {
+    throw new UploadError(`Invalid environment name: ${environment}`, { environment });
+  }
+
+  if (port && !validateSerialPort(port)) {
+    throw new UploadError(`Invalid serial port: ${port}`, { port });
+  }
+
+  try {
+    const args: string[] = ['run', '--target', 'uploadfs'];
+
+    // Add environment if specified
+    if (environment) {
+      args.push('--environment', environment);
+    }
+
+    // Add upload port if specified
+    if (port) {
+      args.push('--upload-port', port);
+    }
+
+    const result = await platformioExecutor.execute('run', args.slice(1), {
+      cwd: validatedPath,
+      timeout: 300000, // 5 minutes
+    });
+
+    const success = result.exitCode === 0;
+    const errors = success ? undefined : parseStderrErrors(result.stderr);
+
+    return {
+      success,
+      port,
+      output: result.stdout,
+      errors,
+    };
+  } catch (error) {
+    if (error instanceof PlatformIOError) {
+      throw new UploadError(
+        `Filesystem upload failed: ${error.message}`,
+        { projectDir, port, environment }
+      );
+    }
+    throw new UploadError(
+      `Failed to upload filesystem: ${error}`,
+      { projectDir, port, environment }
+    );
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -289,6 +289,13 @@ export const UploadFirmwareParamsSchema = z.object({
   environment: z.string().optional().describe('Specific environment to upload (from platformio.ini)'),
 });
 
+// Upload filesystem parameters
+export const UploadFilesystemParamsSchema = z.object({
+  projectDir: z.string().min(1).describe('Path to the PlatformIO project directory'),
+  port: z.string().optional().describe('Upload port (auto-detected if not specified)'),
+  environment: z.string().optional().describe('Specific environment to upload (from platformio.ini)'),
+});
+
 // Start monitor parameters
 export const StartMonitorParamsSchema = z.object({
   port: z.string().optional().describe('Serial port to monitor (auto-detected if not specified)'),


### PR DESCRIPTION
## Summary

Adds a new MCP tool `upload_filesystem` that uploads filesystem images (SPIFFS, LittleFS) from the project's `data/` directory to a connected device.

This complements `upload_firmware` by allowing deployment of web assets, configuration files, and other static content stored in the data folder.

## Motivation

ESP32/ESP8266 projects with web interfaces often need to upload both:
- **Firmware** (C++ code from `src/`) via `upload_firmware`
- **Filesystem** (HTML/JS/CSS from `data/`) via `upload_filesystem`

Currently, the MCP server only supports firmware uploads. This leaves users needing to use the CLI directly for filesystem uploads, breaking the MCP workflow.

## Implementation

The tool runs `pio run --target uploadfs` and supports:
- Automatic port detection
- Environment selection from platformio.ini
- Manual port specification

Files changed:
- `src/tools/upload.ts` - Added `uploadFilesystem()` function
- `src/types.ts` - Added `UploadFilesystemParamsSchema`
- `src/index.ts` - Added tool definition and handler

## Test plan

- [ ] Build succeeds (`npm run build`)
- [ ] Tool appears in MCP tool list
- [ ] Upload works on ESP32 project with SPIFFS filesystem
- [ ] Upload works on ESP8266 project with LittleFS filesystem

🤖 Generated with [Claude Code](https://claude.ai/code)