### PR TITLE
fix(dashboard): hydrate monitor tabs with historical log content on (re)open

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1025,17 +1025,18 @@ export function startPortalServer(defaultPort = 8080) {
     const spoolers = getSpoolerStates();
     socket.emit("spooler_states", spoolers);
     
-    // Hydrate last 50 lines of active serial logs
+    // Hydrate last 1000 lines of active serial logs
     for (const [port, daemon] of Object.entries(spoolers)) {
       if (daemon.logFile && fs.existsSync(daemon.logFile)) {
         try {
-          socket.emit("serial_clear", { port });
+          socket.emit("serial_clear", { port, taskId: daemon.taskId });
 
           const lines = await tailFileBounded(daemon.logFile);
-          const tailLines = lines.slice(-50);
+          const tailLines = lines.slice(-1000);
           socket.emit("serial_log", {
             timestamp: Date.now(),
             port,
+            taskId: daemon.taskId,
             data: tailLines.join("\n")
           });
         } catch (e) {}

--- a/src/tools/monitor.ts
+++ b/src/tools/monitor.ts
@@ -186,11 +186,28 @@ export async function rehydrateMonitors(): Promise<void> {
               }
             } catch {}
 
+            // Restore taskId from the command registry so hydration events carry the correct key.
+            // The original startMonitor() stored it via registerPioMonitorPid → registerCommand.
+            let restoredTaskId: string | undefined;
+            try {
+              const history = getCommandHistory();
+              const cmd = [...history].reverse().find(c =>
+                c.tasks?.some(t => t.type === "monitor" && t.status === "running" && t.port === port)
+              );
+              restoredTaskId = cmd?.tasks.find(
+                t => t.type === "monitor" && t.status === "running" && t.port === port
+              )?.taskId;
+            } catch {}
+            if (!restoredTaskId) {
+              restoredTaskId = crypto.randomUUID();
+            }
+
             const daemon: DaemonContext = {
               baudRate: 115200, // Placeholder
               hwid: null,
               logFile,
               fileOffset: currentSize,
+              taskId: restoredTaskId,
             };
             activeDaemons[port] = daemon;
 


### PR DESCRIPTION
### What this PR does

Fixes monitor tab hydration so that reopening a monitor tab (via page reload, WebSocket reconnect, or tab close/reopen) displays historical serial log content from disk instead of showing a blank terminal that only tails from the current moment.

Two changes in two files:

**`src/api/server.ts`** — The Socket.io connection handler's hydration loop was emitting `serial_clear` and `serial_log` events without including `daemon.taskId`. The React client keys serial log state by `data.artifactId || data.taskId` and silently drops events where neither is present. This PR adds `taskId: daemon.taskId` to both emissions and increases the hydration volume from 50 to 1000 lines (matching the client-side buffer cap).

**`src/tools/monitor.ts`** — `rehydrateMonitors()` (called after MCP server restart to reconnect to orphaned monitor processes) was constructing `DaemonContext` objects without a `taskId`. This meant the `spoolerStates` broadcast and all subsequent `fs.watch()` tailing events lacked the key the client needs. This PR restores the `taskId` by looking it up from the command registry (where `startMonitor()` originally stored it via `registerPioMonitorPid`), falling back to `crypto.randomUUID()` if the registry entry is missing.

### Why these changes are necessary

The dashboard's serial log rendering pipeline is keyed entirely by `taskId`. Without it, hydration data is emitted by the server but silently discarded by the client — the terminal appears empty even though the log file on disk contains the full history. This affects every dashboard reload and every MCP server restart, making the monitor tab appear broken for any session that isn't continuously connected from the moment monitoring starts.

### Testing

- TypeScript compilation: `npm run build` passes cleanly (both server TSC and Vite dashboard bundle)
- Manual verification checklist:
  1. Start a monitor → accumulate output → reload dashboard → historical content should appear (up to 1000 lines)
  2. Close monitor tab → reopen → content persists
  3. Restart MCP server → monitor tab shows historical content with correct keying