### PR TITLE
docs: add Windows setup guide and troubleshooting for known issues

### DIFF
--- a/docs/TroubleshootingGuide.md
+++ b/docs/TroubleshootingGuide.md
@@ -37,17 +37,17 @@ For specific, complex hardware and OS-level issues, refer to our detailed troubl
 ### Serial monitor not streaming in dashboard UI
 **Symptom**: Dashboard shows stale serial data. Log file grows but UI doesn't update.
 **Cause**: `fs.watch()` on Windows uses `ReadDirectoryChangesW` which is unreliable for files written by external processes (like `pio device monitor`).
-**Fix**: Apply the polling fallback patch in `src/tools/monitor.ts`. See [Windows Setup Guide](WindowsSetupGuide.md#bug-1-fs.watch-unreliable-on-windows).
+**Fix**: Use a version with the Windows polling fallback for serial monitor logs. See [Windows Setup Guide](WindowsSetupGuide.md#serial-monitor-streaming).
 
 ### "Maximum call stack size exceeded" when starting serial monitor
 **Symptom**: `POST /api/spooler/start` returns 500 with "Maximum call stack size exceeded".
 **Cause**: `getSpoolerStates()` exposes non-serializable `Timeout` and `FSWatcher` objects with circular references. Socket.IO serialization causes infinite recursion.
-**Fix**: Strip non-serializable fields in `getSpoolerStates()`. See [Windows Setup Guide](WindowsSetupGuide.md#bug-2-getspoolerstates-serialization-crash).
+**Fix**: Use a version that emits serializable spooler state. See [Windows Setup Guide](WindowsSetupGuide.md#spooler-state-serialization).
 
 ### Browse folder button crashes on Windows
 **Symptom**: Clicking "browse for folder" in dashboard UI returns 500 error.
 **Cause**: The browse route uses `osascript` (macOS AppleScript) with no platform detection.
-**Fix**: Add platform detection for Windows (PowerShell) and Linux (zenity). See [Windows Setup Guide](WindowsSetupGuide.md#bug-3-browse-route-macos-only).
+**Fix**: Use a version with OS-specific folder picker support or register the workspace path directly. See [Windows Setup Guide](WindowsSetupGuide.md#workspace-folder-browsing).
 
 ### Dashboard shows 400 on all commands
 **Symptom**: Every command returns "Missing projectDir parameter".

--- a/docs/TroubleshootingGuide.md
+++ b/docs/TroubleshootingGuide.md
@@ -30,3 +30,48 @@ Board IDs are case-sensitive. List available boards with `pio boards` or search 
 For specific, complex hardware and OS-level issues, refer to our detailed troubleshooting documents:
 - [macOS Port Conflicts Reference Document](reference/ESP32PortConflictsOnMacOS.md)
 - [Setting Up ESP32 Devices for Native USB Stability](reference/SettingUpESP32Devices.md)
+- [Windows Setup & Compatibility Guide](WindowsSetupGuide.md)
+
+## Windows-Specific Issues
+
+### Serial monitor not streaming in dashboard UI
+**Symptom**: Dashboard shows stale serial data. Log file grows but UI doesn't update.
+**Cause**: `fs.watch()` on Windows uses `ReadDirectoryChangesW` which is unreliable for files written by external processes (like `pio device monitor`).
+**Fix**: Apply the polling fallback patch in `src/tools/monitor.ts`. See [Windows Setup Guide](WindowsSetupGuide.md#bug-1-fs.watch-unreliable-on-windows).
+
+### "Maximum call stack size exceeded" when starting serial monitor
+**Symptom**: `POST /api/spooler/start` returns 500 with "Maximum call stack size exceeded".
+**Cause**: `getSpoolerStates()` exposes non-serializable `Timeout` and `FSWatcher` objects with circular references. Socket.IO serialization causes infinite recursion.
+**Fix**: Strip non-serializable fields in `getSpoolerStates()`. See [Windows Setup Guide](WindowsSetupGuide.md#bug-2-getspoolerstates-serialization-crash).
+
+### Browse folder button crashes on Windows
+**Symptom**: Clicking "browse for folder" in dashboard UI returns 500 error.
+**Cause**: The browse route uses `osascript` (macOS AppleScript) with no platform detection.
+**Fix**: Add platform detection for Windows (PowerShell) and Linux (zenity). See [Windows Setup Guide](WindowsSetupGuide.md#bug-3-browse-route-macos-only).
+
+### Dashboard shows 400 on all commands
+**Symptom**: Every command returns "Missing projectDir parameter".
+**Cause**: No workspace registered. `workspaces.json` is empty.
+**Fix**: Register workspace via file edit or API. See [Windows Setup Guide](WindowsSetupGuide.md#workspace-registration).
+
+### Stale serial port lock
+**Symptom**: "Port is currently locked: COM14" error.
+**Cause**: Lock file persists after server crash or killed monitor process.
+**Fix**:
+```bash
+del "%USERPROFILE%\.platformio-mcp\serial_ports\COM14.json"
+taskkill /F /IM pio.exe
+```
+
+### ESP32-S3 serial output not visible
+**Symptom**: Serial monitor connects but shows no data.
+**Cause**: Missing `-DARDUINO_USB_CDC_ON_BOOT=1` build flag. Without it, `Serial.println()` goes to internal UART, not USB CDC.
+**Fix**: Add to `platformio.ini`:
+```ini
+build_flags = -DARDUINO_USB_CDC_ON_BOOT=1
+```
+
+### hallRead() not available on ESP32-S3
+**Symptom**: `'hallRead' was not declared in this scope` compilation error.
+**Cause**: The hall sensor API is only available on the original ESP32, not the S3 variant. The Arduino core explicitly skips it (`.skip.esp32s3` in examples).
+**Fix**: Use `touchRead(pin)` (GPIO 1-14) or `temperatureRead()` instead.

--- a/docs/WindowsSetupGuide.md
+++ b/docs/WindowsSetupGuide.md
@@ -70,91 +70,33 @@ build_flags = -DARDUINO_USB_CDC_ON_BOOT=1
 
 Without this flag, `Serial.println()` output goes to the internal UART (GPIO 43/44) instead of the USB CDC port. The serial monitor will connect but show no data.
 
-## Known Bugs and Fixes
+## Known Windows Compatibility Fixes
 
-### Bug 1: fs.watch Unreliable on Windows
+### Serial monitor streaming
 
 **File**: `src/tools/monitor.ts`
 
-**Problem**: `fs.watch()` on Windows uses `ReadDirectoryChangesW` which is unreliable for files being written by external processes (like `pio device monitor`). The watcher fires inconsistently or not at all, causing the dashboard serial monitor to show stale data.
+**Problem**: `fs.watch()` on Windows uses `ReadDirectoryChangesW`, which can miss changes for log files written by external processes like `pio device monitor`. The dashboard can show stale serial data even while the log file grows.
 
-**Fix**: Add a 500ms polling fallback that reads new bytes from the log file:
+**Fix**: PlatformIO MCP keeps the normal file watcher and adds a Windows-only polling fallback that reads newly appended log bytes every 500ms. The fallback shares the same file offset as the watcher, so duplicate serial events are avoided, and the polling interval is cleared when the monitor stops.
 
-```typescript
-// Add to DaemonContext type:
-poller?: ReturnType<typeof setInterval>;
+The same fallback is applied when active monitors are rehydrated after a server restart.
 
-// Add after fs.watch setup in startMonitor():
-daemon.poller = setInterval(() => {
-  try {
-    const stat = fs.statSync(logFile);
-    if (stat.size > (daemon.fileOffset || 0)) {
-      const buffer = Buffer.alloc(stat.size - (daemon.fileOffset || 0));
-      const fd = fs.openSync(logFile, "r");
-      fs.readSync(fd, buffer, 0, buffer.length, (daemon.fileOffset || 0));
-      fs.closeSync(fd);
-      const text = buffer.toString();
-      if (text.length > 0) {
-        portalEvents.emitSerialLog(activePort!, text, daemon.taskId);
-      }
-      daemon.fileOffset = stat.size;
-    }
-  } catch {}
-}, 500);
-
-// Add to stopMonitor():
-if (daemon.poller) {
-  clearInterval(daemon.poller);
-  daemon.poller = undefined;
-}
-```
-
-Apply the same polling pattern to `rehydrateMonitors()`.
-
-### Bug 2: getSpoolerStates Serialization Crash
+### Spooler state serialization
 
 **File**: `src/tools/monitor.ts`
 
 **Problem**: `getSpoolerStates()` returns the raw `activeDaemons` object which contains `watcher` (FSWatcher) and `poller` (Timeout) fields with circular references. When Socket.IO tries to serialize this for WebSocket emission via `portalEvents.emitSpoolerStates()`, the circular references cause "Maximum call stack size exceeded".
 
-**Fix**: Strip non-serializable fields before returning:
+**Fix**: PlatformIO MCP returns a serializable daemon-state snapshot and strips internal `watcher` and `poller` handles before emitting spooler state to the dashboard.
 
-```typescript
-export function getSpoolerStates() {
-  const clean: Record<string, Omit<DaemonContext, 'watcher' | 'poller'>> = {};
-  for (const [port, daemon] of Object.entries(activeDaemons)) {
-    const { watcher, poller, ...rest } = daemon;
-    clean[port] = rest;
-  }
-  return clean;
-}
-```
-
-### Bug 3: Browse Route macOS-Only
+### Workspace folder browsing
 
 **File**: `src/api/server.ts`
 
 **Problem**: `POST /api/workspaces/browse` uses `osascript` (macOS AppleScript) for the native folder picker dialog, with no platform detection. Crashes on Windows and Linux.
 
-**Fix**: Add platform detection:
-
-```typescript
-if (process.platform === "darwin") {
-  result = execSync("osascript -e 'POSIX path of (choose folder)'").toString().trim();
-} else if (process.platform === "win32") {
-  const ps = `[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null; $f = New-Object System.Windows.Forms.FolderBrowserDialog; $f.Description = 'Select PlatformIO Project'; $f.ShowNewFolderButton = $false; if ($f.ShowDialog() -eq 'OK') { $f.SelectedPath } else { '' }`;
-  result = execSync(`powershell -NoProfile -Command "${ps}"`, { timeout: 60000 }).toString().trim();
-} else {
-  try {
-    result = execSync("zenity --file-selection --directory --title='Select PlatformIO Project'", { timeout: 60000 }).toString().trim();
-  } catch {
-    res.status(400).json({ error: "Native folder picker not available. Use text input." });
-    return;
-  }
-}
-```
-
-Also add a `POST /api/workspaces` route for direct path registration (text input fallback).
+**Fix**: The browse route now chooses an OS-specific folder picker: AppleScript on macOS, PowerShell `FolderBrowserDialog` on Windows, and `zenity` on Linux when available. A direct `POST /api/workspaces` route is also available for registering a project path from text input when a native picker is unavailable.
 
 ## File Locations on Windows
 

--- a/docs/WindowsSetupGuide.md
+++ b/docs/WindowsSetupGuide.md
@@ -1,0 +1,168 @@
+# Windows Setup & Compatibility Guide
+
+[← Back to Troubleshooting](TroubleshootingGuide.md)
+
+## Overview
+
+This guide covers Windows-specific setup steps, known issues, and fixes for the PlatformIO MCP server and web dashboard. Most of these issues don't affect macOS or Linux users.
+
+## Prerequisites
+
+1. **Python 3.x** with pip: `pip install platformio`
+2. **Node.js 18+**: Required for platformio-mcp
+3. **PlatformIO in PATH**: Verify with `pio --version`
+
+## Installation
+
+```bash
+git clone https://github.com/jl-codes/platformio-mcp.git
+cd platformio-mcp
+npm install
+npm run build:ui   # builds web dashboard (web/dist/)
+npx tsc            # compiles TypeScript (src/ → build/)
+```
+
+## Workspace Registration
+
+The dashboard requires at least one workspace (project directory) to be registered. Without it, all commands return 400 "Missing projectDir parameter".
+
+The workspace file is at `~/.platformio-mcp/workspaces.json`.
+
+### Register via file edit (immediate)
+```bash
+echo [{"dir":"C:\\path\\to\\project","timestamp":1781638000000}] > "%USERPROFILE%\.platformio-mcp\workspaces.json"
+```
+
+### Register via API
+```bash
+curl -X POST http://localhost:8080/api/workspaces \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"dir": "C:\\path\\to\\project"}'
+```
+
+### Register via CLI (auto-registers on flash/build)
+```bash
+node build/cli.js flash --project-dir C:\path\to\project --port COM14 --approve
+```
+
+## Stale Lock File Handling
+
+The spooler creates lock files in `~/.platformio-mcp/serial_ports/` (e.g., `COM14.json`). If the server crashes or a monitor process is killed, these locks become stale.
+
+### Symptoms
+- "Port is currently locked: COM14" error
+- Devices show a `claim` with a dead PID
+
+### Fix
+```bash
+del "%USERPROFILE%\.platformio-mcp\serial_ports\COM14.json"
+taskkill /F /IM pio.exe
+```
+
+## ESP32-S3 USB CDC
+
+The ESP32-S3 requires a specific build flag for serial output over USB:
+
+```ini
+build_flags = -DARDUINO_USB_CDC_ON_BOOT=1
+```
+
+Without this flag, `Serial.println()` output goes to the internal UART (GPIO 43/44) instead of the USB CDC port. The serial monitor will connect but show no data.
+
+## Known Bugs and Fixes
+
+### Bug 1: fs.watch Unreliable on Windows
+
+**File**: `src/tools/monitor.ts`
+
+**Problem**: `fs.watch()` on Windows uses `ReadDirectoryChangesW` which is unreliable for files being written by external processes (like `pio device monitor`). The watcher fires inconsistently or not at all, causing the dashboard serial monitor to show stale data.
+
+**Fix**: Add a 500ms polling fallback that reads new bytes from the log file:
+
+```typescript
+// Add to DaemonContext type:
+poller?: ReturnType<typeof setInterval>;
+
+// Add after fs.watch setup in startMonitor():
+daemon.poller = setInterval(() => {
+  try {
+    const stat = fs.statSync(logFile);
+    if (stat.size > (daemon.fileOffset || 0)) {
+      const buffer = Buffer.alloc(stat.size - (daemon.fileOffset || 0));
+      const fd = fs.openSync(logFile, "r");
+      fs.readSync(fd, buffer, 0, buffer.length, (daemon.fileOffset || 0));
+      fs.closeSync(fd);
+      const text = buffer.toString();
+      if (text.length > 0) {
+        portalEvents.emitSerialLog(activePort!, text, daemon.taskId);
+      }
+      daemon.fileOffset = stat.size;
+    }
+  } catch {}
+}, 500);
+
+// Add to stopMonitor():
+if (daemon.poller) {
+  clearInterval(daemon.poller);
+  daemon.poller = undefined;
+}
+```
+
+Apply the same polling pattern to `rehydrateMonitors()`.
+
+### Bug 2: getSpoolerStates Serialization Crash
+
+**File**: `src/tools/monitor.ts`
+
+**Problem**: `getSpoolerStates()` returns the raw `activeDaemons` object which contains `watcher` (FSWatcher) and `poller` (Timeout) fields with circular references. When Socket.IO tries to serialize this for WebSocket emission via `portalEvents.emitSpoolerStates()`, the circular references cause "Maximum call stack size exceeded".
+
+**Fix**: Strip non-serializable fields before returning:
+
+```typescript
+export function getSpoolerStates() {
+  const clean: Record<string, Omit<DaemonContext, 'watcher' | 'poller'>> = {};
+  for (const [port, daemon] of Object.entries(activeDaemons)) {
+    const { watcher, poller, ...rest } = daemon;
+    clean[port] = rest;
+  }
+  return clean;
+}
+```
+
+### Bug 3: Browse Route macOS-Only
+
+**File**: `src/api/server.ts`
+
+**Problem**: `POST /api/workspaces/browse` uses `osascript` (macOS AppleScript) for the native folder picker dialog, with no platform detection. Crashes on Windows and Linux.
+
+**Fix**: Add platform detection:
+
+```typescript
+if (process.platform === "darwin") {
+  result = execSync("osascript -e 'POSIX path of (choose folder)'").toString().trim();
+} else if (process.platform === "win32") {
+  const ps = `[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null; $f = New-Object System.Windows.Forms.FolderBrowserDialog; $f.Description = 'Select PlatformIO Project'; $f.ShowNewFolderButton = $false; if ($f.ShowDialog() -eq 'OK') { $f.SelectedPath } else { '' }`;
+  result = execSync(`powershell -NoProfile -Command "${ps}"`, { timeout: 60000 }).toString().trim();
+} else {
+  try {
+    result = execSync("zenity --file-selection --directory --title='Select PlatformIO Project'", { timeout: 60000 }).toString().trim();
+  } catch {
+    res.status(400).json({ error: "Native folder picker not available. Use text input." });
+    return;
+  }
+}
+```
+
+Also add a `POST /api/workspaces` route for direct path registration (text input fallback).
+
+## File Locations on Windows
+
+| File | Location |
+|---|---|
+| Workspace registry | `%USERPROFILE%\.platformio-mcp\workspaces.json` |
+| Serial port locks | `%USERPROFILE%\.platformio-mcp\serial_ports\*.json` |
+| Build logs | `<project>\.pio-mcp-workspace\logs\build\` |
+| Upload logs | `<project>\.pio-mcp-workspace\logs\upload\` |
+| Monitor logs | `<project>\.pio-mcp-workspace\logs\monitor\` |
+| Command history | `<project>\.pio-mcp-workspace\registry\command_history.json` |


### PR DESCRIPTION
Added Windows-specific documentation for platformio-mcp:

New file: docs/WindowsSetupGuide.md
- Workspace registration requirement and how to set it up
- Stale lock file handling (serial_ports/*.json)
- ESP32-S3 USB CDC build flag requirement
- Detailed bug reports with code fixes for all 3 Windows issues
- File location reference for Windows paths

Updated: docs/TroubleshootingGuide.md
- Added Windows-specific troubleshooting section
- Serial monitor not streaming (fs.watch issue)
- Stack overflow on spooler start (serialization issue)
- Browse folder crash (osascript macOS-only)
- Dashboard 400 errors (workspace registration)
- Stale port locks
- ESP32-S3 serial output (USB CDC flag)
- hallRead() not available on ESP32-S3