### PR TITLE
Fix build_project sending duplicate 'run' arg to pio CLI

### DIFF
--- a/src/tools/build.ts
+++ b/src/tools/build.ts
@@ -22,7 +22,7 @@ export async function buildProject(
   }
 
   try {
-    const args: string[] = ['run'];
+    const args: string[] = [];
 
     // Add environment if specified
     if (environment) {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { platformioExecutor } from '../src/platformio.js';
+import { buildProject } from '../src/tools/build.js';
+
+// Regression test for: buildProject invoking `pio run run ...` (duplicate
+// positional 'run' argument) which PlatformIO's CLI rejects with
+// "Error: Got unexpected extra argument (run)". Root cause: buildProject put
+// 'run' in its own args array on top of PlatformIOExecutor.execute() already
+// prepending the command name.
+
+describe('buildProject', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not duplicate the command name in the args passed to pio', async () => {
+    const executeSpy = vi
+      .spyOn(platformioExecutor, 'execute')
+      .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+    await buildProject(process.cwd(), 'someenv');
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    const [command, args] = executeSpy.mock.calls[0];
+    expect(command).toBe('run');
+    expect(args).not.toContain('run');
+    expect(args).toEqual(['--environment', 'someenv']);
+  });
+});


### PR DESCRIPTION
## Summary

`buildProject()` in `src/tools/build.ts` built its args array starting
with `'run'`, then called `platformioExecutor.execute('run', args, ...)`.
`PlatformIOExecutor.execute()` already prepends the command name
(`fullArgs = [command, ...args]`), so `'run'` ended up in the argv twice:

```
pio run run --environment X
```

PlatformIO's Click-based CLI rejects the extra positional argument with:

```
Error: Got unexpected extra argument (run)
```

This made `build_project` fail on every call that passed an `environment`
(and, less obviously, even without one), regardless of project path.

The other call sites in the same file (`buildTarget`, `listTargets`) and
in `upload.ts`/`projects.ts` already avoid this by omitting/stripping the
leading `'run'`/`'project'` before calling `execute()` -- `buildProject`
was the one place that didn't.

## Fix

One-line change: don't put `'run'` in `buildProject`'s own `args` array,
since `execute('run', args)` already adds it.

## Test plan

- Added `tests/build.test.ts` (vitest) asserting `buildProject` calls
  `execute('run', args)` with `args` free of a duplicate `'run'`. Confirmed
  it fails against the pre-fix code with the original error signature and
  passes after the fix.
- Ran a real build through `buildProject()` against a minimal
  `platform = native` project and confirmed `success: true`.
- `npm run build` (tsc) succeeds.

Note: `npm run lint` and `npx prettier --check` both fail on this repo's
pre-existing files (no ESLint config is committed, and prettier flags files
untouched by this PR too), so I left those as-is rather than reformatting
unrelated code.