### PR TITLE
fix(release): publish local npm tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
             if npm view "${package_name}@${version}" version >/dev/null 2>&1; then
               echo "${package_name}@${version} is already published; skipping"
             else
-              npm publish "release-artifacts/${package_name}-${version}.tgz" --access public
+              npm publish "./release-artifacts/${package_name}-${version}.tgz" --access public
             fi
           done
 


### PR DESCRIPTION
## Summary
- prefix release tarball paths with ./ so npm treats them as local files instead of GitHub shorthand
- unblock the v3.0.0 OIDC release after run 34267543206 failed before publishing any package

## Verification
- npm publish ./release-artifacts/platformio-mcp-3.0.0.tgz --access public --dry-run
- npm publish ./release-artifacts/pio-mcp-3.0.0.tgz --access public --dry-run
- npx prettier --check .github/workflows/release.yml
- git diff --check