### PR TITLE
Publish pio-agent as an npm compatibility package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,10 @@ jobs:
           mkdir -p release-artifacts
           npm pack
           npm pack ./packages/pio-mcp
+          npm pack ./packages/pio-agent
           mv "platformio-mcp-${version}.tgz" release-artifacts/
           mv "pio-mcp-${version}.tgz" release-artifacts/
+          mv "pio-agent-${version}.tgz" release-artifacts/
           cp plugins/platformio-mcp/runtime/inventory.json release-artifacts/plugin-runtime-inventory.json
 
       - name: Upload immutable artifacts
@@ -84,7 +86,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.publish_npm
         run: |
           version="$(node -p "require('./package.json').version")"
-          for package_name in platformio-mcp pio-mcp; do
+          for package_name in platformio-mcp pio-mcp pio-agent; do
             if npm view "${package_name}@${version}" version >/dev/null 2>&1; then
               echo "${package_name}@${version} is already published; skipping"
             else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   health, and bounded lab checks with quiet healthy-state behavior.
 - **PIO Agent branding and CLI alias** while preserving `platformio-mcp` as the
   stable npm package, executable, MCP server, and Codex plugin identifier.
+- **Installable npm compatibility names** for `pio-mcp` and `pio-agent`, both
+  delegating to the canonical `platformio-mcp` CLI implementation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PIO Agent is the open-source, agent-first hardware execution layer for embedded 
 
 ## Brand and Compatibility
 
-**PIO Agent** is the product and Codex Plugin name. **PlatformIO MCP** is the underlying MCP runtime and the compatibility identity used by existing installations. The package, Codex plugin ID, marketplace ID, configuration keys, and skill namespace remain `platformio-mcp`; both `pio-agent` and `platformio-mcp` are supported executable names. This lets existing consumers upgrade without migration while new users see PIO Agent throughout the interface.
+**PIO Agent** is the product and Codex Plugin name. **PlatformIO MCP** is the underlying MCP runtime and the compatibility identity used by existing installations. The Codex plugin ID, marketplace ID, configuration keys, and skill namespace remain `platformio-mcp`. On npm, `platformio-mcp` is the canonical package while `pio-mcp` and `pio-agent` are thin compatibility packages that delegate to it. The canonical package also installs both `platformio-mcp` and `pio-agent` executable names. This lets existing consumers upgrade without migration while new users see PIO Agent throughout the interface.
 
 It exposes PlatformIO workflows for board discovery, project setup, build, flash, monitor, diagnostics, and task orchestration through:
 - an MCP server adapter
@@ -43,10 +43,12 @@ npx platformio-mcp dashboard
 
 ### 2. Use the CLI
 
-The installed executable is available as both `pio-agent` and `platformio-mcp`. For a one-off npm invocation before global installation, select the existing package explicitly:
+All three npm names are supported. `platformio-mcp` is canonical; `pio-mcp` and `pio-agent` install the same CLI through thin dependency-only aliases:
 
 ```bash
-npx --package platformio-mcp pio-agent --help
+npx platformio-mcp --help
+npx pio-mcp --help
+npx pio-agent --help
 ```
 
 ```bash

--- a/docs/CODEX_PLUGIN_RELEASE.md
+++ b/docs/CODEX_PLUGIN_RELEASE.md
@@ -70,15 +70,16 @@ The initial one-board usability gate is documented in the [redacted ESP32-S3 acc
 
 ## Release
 
-1. Update the package, compatibility-package, plugin, and changelog versions.
+1. Update the canonical package, both compatibility packages, plugin, and changelog versions.
 2. Regenerate plugin content and runtime.
 3. Run all software, browser, package, secret-scan, and available hardware gates.
 4. Update the draft PR with exact evidence and residual matrix gaps; mark ready only when required evidence exists.
-5. Configure npm trusted publishing for both `platformio-mcp` and its existing
-   `pio-mcp` compatibility package, repository `jl-codes/platformio-mcp`,
-   workflow `release.yml`, with direct publishing allowed. The release workflow
-   uses a GitHub-hosted Node 24 runner and OIDC; it does not require a long-lived
-   npm token.
+5. Configure npm trusted publishing for `platformio-mcp` plus the `pio-mcp` and
+   `pio-agent` compatibility packages, repository `jl-codes/platformio-mcp`,
+   workflow `release.yml`, with direct publishing allowed. A new compatibility
+   package must first be published once by an npm owner before npm exposes its
+   trusted-publisher settings. The release workflow uses a GitHub-hosted Node 24
+   runner and OIDC; routine releases do not require a long-lived npm token.
 6. Merge after review, create the signed `v<package-version>` tag, and manually
    dispatch the release workflow from that exact tag with npm publishing
    enabled if authorized.

--- a/packages/pio-agent/README.md
+++ b/packages/pio-agent/README.md
@@ -1,0 +1,16 @@
+# pio-agent
+
+Product-name npm alias for [PIO Agent](https://www.npmjs.com/package/platformio-mcp).
+It delegates entirely to the canonical `platformio-mcp` package and preserves
+the same CLI behavior.
+
+```bash
+npx pio-agent dashboard
+npx pio-agent install --codex
+npx pio-agent install --codex-plugin
+npx pio-agent devices
+npx pio-agent boards --filter esp32
+```
+
+For full documentation see the
+[platformio-mcp README](https://github.com/jl-codes/platformio-mcp#readme).

--- a/packages/pio-agent/bin.js
+++ b/packages/pio-agent/bin.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+/**
+ * pio-agent — product-name binary that delegates entirely to platformio-mcp.
+ *
+ * The canonical CLI inspects process.argv directly, so importing its entrypoint
+ * forwards every command and option without maintaining a second implementation.
+ */
+import("platformio-mcp/build/cli.js");

--- a/packages/pio-agent/package.json
+++ b/packages/pio-agent/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "pio-agent",
+  "version": "3.0.0",
+  "description": "Product-name npm alias for PIO Agent, powered by the canonical platformio-mcp package.",
+  "type": "module",
+  "bin": {
+    "pio-agent": "bin.js"
+  },
+  "files": [
+    "bin.js",
+    "README.md"
+  ],
+  "dependencies": {
+    "platformio-mcp": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "mcp",
+    "platformio",
+    "pio-agent",
+    "embedded",
+    "arduino",
+    "esp32",
+    "stm32",
+    "alias"
+  ],
+  "author": "PIO Agent Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jl-codes/platformio-mcp.git",
+    "directory": "packages/pio-agent"
+  },
+  "bugs": {
+    "url": "https://github.com/jl-codes/platformio-mcp/issues"
+  },
+  "homepage": "https://github.com/jl-codes/platformio-mcp#readme"
+}

--- a/scripts/validate-npm-package.mjs
+++ b/scripts/validate-npm-package.mjs
@@ -14,7 +14,9 @@ import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const ALIAS_ROOT = resolve(REPO_ROOT, "packages", "pio-mcp");
+
+/** Thin npm packages that expose supported names for the canonical CLI. */
+const COMPATIBILITY_PACKAGES = ["pio-mcp", "pio-agent"];
 
 /** Files that make the published server and Codex plugin usable. */
 const REQUIRED_FILES = [
@@ -29,8 +31,8 @@ const REQUIRED_FILES = [
   "web/dist/index.html",
 ];
 
-/** Files required for the published pio-mcp compatibility package. */
-const ALIAS_REQUIRED_FILES = ["README.md", "bin.js", "package.json"];
+/** Files required for each published compatibility package. */
+const COMPATIBILITY_REQUIRED_FILES = ["README.md", "bin.js", "package.json"];
 
 /** Content that must never leave a developer or CI workspace in an npm package. */
 const FORBIDDEN_PATHS = [
@@ -193,31 +195,43 @@ function scanPackedText(packageRoot, paths) {
 }
 
 const packageJson = readJson("package.json");
-const aliasPackageJson = readJson("packages/pio-mcp/package.json");
 const report = inspectPackage(".");
-const aliasReport = inspectPackage("./packages/pio-mcp");
 const paths = validateReport(report, packageJson, REQUIRED_FILES);
-const aliasPaths = validateReport(
-  aliasReport,
-  aliasPackageJson,
-  ALIAS_REQUIRED_FILES,
-);
 scanPackedText(REPO_ROOT, paths);
-scanPackedText(ALIAS_ROOT, aliasPaths);
 
-if (aliasPackageJson.version !== packageJson.version) {
-  throw new Error("pio-mcp and platformio-mcp package versions differ.");
-}
-if (
-  aliasPackageJson.dependencies?.["platformio-mcp"] !==
-  `^${packageJson.version}`
-) {
-  throw new Error("pio-mcp does not depend on the matching 3.x package line.");
-}
+const compatibilityResults = COMPATIBILITY_PACKAGES.map((packageName) => {
+  const packageRoot = resolve(REPO_ROOT, "packages", packageName);
+  const compatibilityPackageJson = readJson(
+    `packages/${packageName}/package.json`,
+  );
+  const compatibilityReport = inspectPackage(`./packages/${packageName}`);
+  const compatibilityPaths = validateReport(
+    compatibilityReport,
+    compatibilityPackageJson,
+    COMPATIBILITY_REQUIRED_FILES,
+  );
+  scanPackedText(packageRoot, compatibilityPaths);
 
-for (const [packageReport, packagePaths] of [
-  [report, paths],
-  [aliasReport, aliasPaths],
+  if (compatibilityPackageJson.version !== packageJson.version) {
+    throw new Error(
+      `${packageName} and platformio-mcp package versions differ.`,
+    );
+  }
+  if (
+    compatibilityPackageJson.dependencies?.["platformio-mcp"] !==
+    `^${packageJson.version}`
+  ) {
+    throw new Error(
+      `${packageName} does not depend on the matching 3.x package line.`,
+    );
+  }
+
+  return { report: compatibilityReport, paths: compatibilityPaths };
+});
+
+for (const { report: packageReport, paths: packagePaths } of [
+  { report, paths },
+  ...compatibilityResults,
 ]) {
   console.log(
     `Validated ${packageReport.name}@${packageReport.version}: ` +

--- a/tests/codex-plugin-launcher.test.ts
+++ b/tests/codex-plugin-launcher.test.ts
@@ -78,22 +78,32 @@ describe("Codex plugin launcher", () => {
     expect(spec.command).toBe("npx");
   });
 
-  it("keeps the pio-mcp compatibility package aligned with the CLI", () => {
-    const aliasRoot = path.join(process.cwd(), "packages", "pio-mcp");
-    const aliasPackage = JSON.parse(
-      fs.readFileSync(path.join(aliasRoot, "package.json"), "utf8"),
-    ) as { dependencies: Record<string, string>; version: string };
-    const aliasLauncher = fs.readFileSync(
-      path.join(aliasRoot, "bin.js"),
-      "utf8",
-    );
+  it.each(["pio-mcp", "pio-agent"])(
+    "keeps the %s compatibility package aligned with the CLI",
+    (packageName) => {
+      const aliasRoot = path.join(process.cwd(), "packages", packageName);
+      const aliasPackage = JSON.parse(
+        fs.readFileSync(path.join(aliasRoot, "package.json"), "utf8"),
+      ) as {
+        bin: Record<string, string>;
+        dependencies: Record<string, string>;
+        name: string;
+        version: string;
+      };
+      const aliasLauncher = fs.readFileSync(
+        path.join(aliasRoot, "bin.js"),
+        "utf8",
+      );
 
-    expect(aliasPackage.version).toBe(PACKAGE_VERSION);
-    expect(aliasPackage.dependencies["platformio-mcp"]).toBe(
-      `^${PACKAGE_VERSION}`,
-    );
-    expect(aliasLauncher).toContain('import("platformio-mcp/build/cli.js")');
-  });
+      expect(aliasPackage.name).toBe(packageName);
+      expect(aliasPackage.version).toBe(PACKAGE_VERSION);
+      expect(aliasPackage.bin[packageName]).toBe("bin.js");
+      expect(aliasPackage.dependencies["platformio-mcp"]).toBe(
+        `^${PACKAGE_VERSION}`,
+      );
+      expect(aliasLauncher).toContain('import("platformio-mcp/build/cli.js")');
+    },
+  );
 });
 
 const describeBundledRuntime = fs.existsSync(RUNTIME_PATH)


### PR DESCRIPTION
Adds pio-agent as a thin npm compatibility package for the canonical platformio-mcp CLI, alongside pio-mcp. Extends packaging validation, release artifacts, OIDC publish sequencing, documentation, and launcher tests to cover all three supported npm names.

Validated locally:
- TypeScript no-emit compile
- lint (0 errors; existing warnings only)
- 157 unit tests
- 14 Codex plugin tests
- 10 UI tests
- npm package validation for all three package identities
- isolated tarball install and CLI smoke test: all three direct launchers and all three generated bin shims report 3.0.0